### PR TITLE
SI-106 Fix admin principal for mainnet deployment

### DIFF
--- a/projects/brain-matters/deploy.sh
+++ b/projects/brain-matters/deploy.sh
@@ -126,11 +126,11 @@ if [[ $IC_NETWORK == 'ic' ]]; then
   fi
 else #local
   bash "$SCRIPTS_PATH/create-local-identity.sh" "$IDENTITY_NAME" "$IDENTITY_PEM_FILE_PATH"
-
-  echo "Getting principal for $IDENTITY_NAME identity"
-  ADMIN_PRINCIPAL=$(dfx identity get-principal)
-  echo "The $IDENTITY_NAME principal is $ADMIN_PRINCIPAL"
 fi
+
+echo "Getting principal for $IDENTITY_NAME identity"
+ADMIN_PRINCIPAL=$(dfx identity get-principal)
+echo "The $IDENTITY_NAME principal is $ADMIN_PRINCIPAL"
 
 show_elapsed_time
 


### PR DESCRIPTION
- When specifying the network as IC (mainnet), the admin principal was not getting set.
- Move code to set the admin principal outside the code block for the local environment.