### PR TITLE
SI-192 Gzip Local Canister

### DIFF
--- a/projects/brain-matters-full/deploy.sh
+++ b/projects/brain-matters-full/deploy.sh
@@ -36,7 +36,7 @@ IC_NETWORK="local"
 # If local network, creates/imports/uses identity if it does exist.
 # If ic network (mainnet), make sure you manually import your existing
 # identity first, then provide the name of your imported identity here.
-IDENTITY_NAME="local_nft_deployer"
+IDENTITY_NAME="local_deployer"
 
 # NFT collection settings
 COLLECTION_ID="bm"
@@ -233,12 +233,8 @@ echo "Building and installing the NFT canister"
 
 dfx build --network $IC_NETWORK origyn_nft_reference
 
-if [[ $IC_NETWORK == 'ic' ]]; then
-  gzip -k ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm
-  dfx canister --network $IC_NETWORK install origyn_nft_reference --mode=reinstall --wasm ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm.gz --argument "(record {owner = principal \"$ADMIN_PRINCIPAL\"; storage_space = null})"
-else
-  dfx canister --network $IC_NETWORK install origyn_nft_reference --mode=reinstall --argument "(record {owner = principal \"$ADMIN_PRINCIPAL\"; storage_space = null})"
-fi
+gzip -k ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm
+dfx canister --network $IC_NETWORK install origyn_nft_reference --mode=reinstall --wasm ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm.gz --argument "(record {owner = principal \"$ADMIN_PRINCIPAL\"; storage_space = opt 2048000000})"
 
 show_elapsed_time
 

--- a/projects/brain-matters-full/post-config.js
+++ b/projects/brain-matters-full/post-config.js
@@ -20,13 +20,14 @@ console.log('metadataFile', metadataFile);
 const allMetadata = JSON.parse(fs.readFileSync(metadataFile).toString());
 
 // Make every other token a soulbound NFT.
-for (let i = 2; i <= 20; i += 2) {
-  const nft = findNft(allMetadata, `bm-${i}`);
-  const is_soulbound = findNftProperty(nft, 'is_soulbound');
+// Just an an example. Put your own code here instead.
+// for (let i = 2; i <= 20; i += 2) {
+//   const nft = findNft(allMetadata, `bm-${i}`);
+//   const is_soulbound = findNftProperty(nft, 'is_soulbound');
 
-  is_soulbound.value.Bool = true;
-  is_soulbound.immutable = true;
-}
+//   is_soulbound.value.Bool = true;
+//   is_soulbound.immutable = true;
+// }
 
 // Save the changes
 fs.writeFileSync(metadataFile, JSON.stringify(allMetadata, null, 2));

--- a/projects/brain-matters/deploy.sh
+++ b/projects/brain-matters/deploy.sh
@@ -36,7 +36,7 @@ IC_NETWORK="local"
 # If local network, creates/imports/uses identity if it does exist.
 # If ic network (mainnet), make sure you manually import your existing
 # identity first, then provide the name of your imported identity here.
-IDENTITY_NAME="local_nft_deployer"
+IDENTITY_NAME="local_deployer"
 
 # NFT collection settings
 COLLECTION_ID="bm"
@@ -233,12 +233,8 @@ echo "Building and installing the NFT canister"
 
 dfx build --network $IC_NETWORK origyn_nft_reference
 
-if [[ $IC_NETWORK == 'ic' ]]; then
-  gzip -k ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm
-  dfx canister --network $IC_NETWORK install origyn_nft_reference --mode=reinstall --wasm ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm.gz --argument "(record {owner = principal \"$ADMIN_PRINCIPAL\"; storage_space = null})"
-else
-  dfx canister --network $IC_NETWORK install origyn_nft_reference --mode=reinstall --argument "(record {owner = principal \"$ADMIN_PRINCIPAL\"; storage_space = null})"
-fi
+gzip -k ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm
+dfx canister --network $IC_NETWORK install origyn_nft_reference --mode=reinstall --wasm ./.dfx/ic/canisters/origyn_nft_reference/origyn_nft_reference.wasm.gz --argument "(record {owner = principal \"$ADMIN_PRINCIPAL\"; storage_space = opt 2048000000})"
 
 show_elapsed_time
 


### PR DESCRIPTION
- gzipped NFT canister for local deployment
   - UnfoldVR was getting an error that it was too large using WSL2 on Windows
- changed local deployer name to local_deployer instead of local_nft_deployer to match the local-network-setup project
- commented out code post deploy script (in brain-matters-full) so it doesn't actually modify the metadata and only serves as an example